### PR TITLE
small fixes to vkpr init (curl instead of git)

### DIFF
--- a/LEIAME.md
+++ b/LEIAME.md
@@ -13,3 +13,25 @@ When cloning this repo please add its folder as a workspace:
 ```
 rit add workspace --name vkpr-formulas --path $(pwd)
 ```
+
+Ritchie must be installed:
+
+```
+curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
+```
+
+## Using containers
+
+You can use temporary containers to test your formulas in a clean environment:
+
+```
+docker run --rm -ti -v $(pwd):/opt centos
+```
+
+Install Ritchie in it and configure the workspace:
+
+```
+curl -fsSL https://commons-repo.ritchiecli.io/install.sh | sed -e 's/sudo//g' | bash
+rit set formula-runner --runner=local
+rit add workspace --name vkpr-formulas --path /opt
+```

--- a/vkpr/init/src/unix/formula/formula.sh
+++ b/vkpr/init/src/unix/formula/formula.sh
@@ -32,8 +32,10 @@ runFormula() {
   installTool "jq"
   installTool "yq"
   installTool "k9s"
-  installGlobals
+
+  installGlobals 
   installBats
+
   # if [ "$RIT_INPUT_BOOLEAN" = "true" ]; then
   #   echoColor "blue" "I've already created formulas using Ritchie."
   # else
@@ -76,17 +78,32 @@ installGlobals() {
 
 installBats(){
   if [[ -f "$VKPR_HOME/bats/bin/bats" ]]; then
-    echoColor "yellow" "Tool $toolName already installed. Skipping."
+    echoColor "yellow" "Bats already installed. Skipping."
   else
-    echoColor "green" "intalling bats..."
+    echoColor "green" "intalling Bats..."
     mkdir -p /tmp/bats
-    git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
+    # bats-core
+    curl -sL -o /tmp/bats-core.tar.gz https://github.com/bats-core/bats-core/archive/refs/tags/v1.4.1.tar.gz
+    tar -xzf /tmp/bats-core.tar.gz -C /tmp
+    mv /tmp/bats-core-1.4.1 /tmp/bats-core
     /tmp/bats-core/install.sh $VKPR_HOME/bats
     rm -r --force /tmp/bats-core
+
     echoColor "green" "intalling bats add-ons..."
-    git clone https://github.com/bats-core/bats-support $VKPR_HOME/bats/bats-support
-    git clone https://github.com/bats-core/bats-assert $VKPR_HOME/bats/bats-assert
-    git clone https://github.com/bats-core/bats-file $VKPR_HOME/bats/bats-file
+    # bats-support
+    #git clone https://github.com/bats-core/bats-support $VKPR_HOME/bats/bats-support
+    curl -sL -o /tmp/bats-support.tar.gz https://github.com/bats-core/bats-support/archive/refs/tags/v0.3.0.tar.gz
+    tar -xzf /tmp/bats-support.tar.gz -C /tmp
+    mv /tmp/bats-support-0.3.0 $VKPR_HOME/bats/bats-support
+    # bats-assert
+    curl -sL -o /tmp/bats-assert.tar.gz https://github.com/bats-core/bats-assert/archive/refs/tags/v2.0.0.tar.gz
+    tar -xzf /tmp/bats-assert.tar.gz -C /tmp
+    mv /tmp/bats-assert-2.0.0 $VKPR_HOME/bats/bats-assert
+    # bats-file
+    curl -sL -o /tmp/bats-file.tar.gz https://github.com/bats-core/bats-file/archive/refs/tags/v0.3.0.tar.gz
+    tar -xzf /tmp/bats-file.tar.gz -C /tmp
+    mv /tmp/bats-file-0.3.0 $VKPR_HOME/bats/bats-file
+    echo "Bats add-ons installed"
   fi
 }
 


### PR DESCRIPTION
`vkpr init` must work even if git is not available 